### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ idna==3.7
 importlib-metadata==7.0.1
 iniconfig==2.0.0
 itsdangerous==2.1.2
-Jinja2==3.1.3
+Jinja2==3.1.4
 MarkupSafe==2.1.5
 packaging==23.2
 pluggy==1.4.0
@@ -22,5 +22,5 @@ python-dotenv==1.0.1
 requests==2.31.0
 tomli==2.0.1
 urllib3==2.2.1
-Werkzeug==3.0.1
+Werkzeug==3.0.3
 zipp==3.17.0


### PR DESCRIPTION
The debugger in affected versions of Werkzeug can allow an attacker to execute code on a developer's machine under some circumstances. This requires the attacker to get the developer to interact with a domain and subdomain they control, and enter the debugger PIN, but if they are successful it allows access to the debugger even if it is only running on localhost. This also requires the attacker to guess a URL in the developer's application that will trigger the debugger.

The xmlattr filter in affected versions of Jinja accepts keys containing non-attribute characters. XML/HTML attributes cannot contain spaces, /, >, or =, as each would then be interpreted as starting a separate attribute. If an application accepts keys (as opposed to only values) as user input, and renders these in pages that other users see as well, an attacker could use this to inject other attributes and perform XSS. The fix for the previous GHSA-h5c8-rqwp-cp95 CVE-2024-22195 only addressed spaces but not other characters.

Accepting keys as user input is now explicitly considered an unintended use case of the xmlattr filter, and code that does so without otherwise validating the input should be flagged as insecure, regardless of Jinja version. Accepting values as user input continues to be safe.